### PR TITLE
Add Sentry SDK to log backend API

### DIFF
--- a/common/urls.py
+++ b/common/urls.py
@@ -1,7 +1,10 @@
 from django.urls import path
 
 from common.views import index
+from common.views import sentry_debug
+
 
 urlpatterns = [
     path('initialsetup/', index, name='initialsetup'),
+    path('sentry-debug/', sentry_debug, name='sentry-debug'),
 ]

--- a/common/views.py
+++ b/common/views.py
@@ -12,3 +12,10 @@ def index(request):
     response = {'message': 'Initial setup complete.'}
 
     return Response(response)
+
+
+@api_view(['GET'])
+def sentry_debug(request):
+    division_by_zero = 1 / 0
+
+    return Response({'message': f'Testing sentry logging: {division_by_zero}'})

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ djangorestframework==3.11.0
 djangorestframework-simplejwt==4.4.0
 psycopg2-binary==2.8.5
 requests==2.23.0
+sentry-sdk==0.16.2

--- a/resourceideaapi/settings.py
+++ b/resourceideaapi/settings.py
@@ -12,6 +12,9 @@ https://docs.djangoproject.com/en/2.1/ref/settings/
 
 import os
 
+import sentry_sdk
+from sentry_sdk.integrations.django import DjangoIntegration
+
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
@@ -152,3 +155,11 @@ REST_FRAMEWORK = {
         'rest_framework.permissions.IsAuthenticated',
     ]
 }
+
+
+# Sentry monitoring setup
+sentry_sdk.init(
+    dsn=os.environ['SENTRY_DSN'],
+    integrations=[DjangoIntegration(), ],
+    send_default_pii=True
+)

--- a/resourceideaapi/urls.py
+++ b/resourceideaapi/urls.py
@@ -36,10 +36,10 @@ urlpatterns = [
     path(f'{BASE_API_URL}', include('job_position.api.urls')),
 
     path('', include('home.urls')),
-    path(f'api/token/',
+    path('api/token/',
          jwt_views.TokenObtainPairView.as_view(),
          name='token_obtain_pair'),
-    path(f'api/token/refresh/',
+    path('api/token/refresh/',
          jwt_views.TokenRefreshView.as_view(),
          name='token_refresh'),
 ]


### PR DESCRIPTION
To track the exceptions, logging with Sentry has been enabled.